### PR TITLE
Testing weekend (Merge 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 The code for the Hyperloop Pod Control systems
 
-* **Core**: the core C control
-* **ODS**: receive logs from the server over TCP
+* **Core**: the core C controller. 
+* **ODS**: receive logs from the pod over TCP
 * **Client**: client (telnet) for interacting with the pod remotely
 
 # Glossary


### PR DESCRIPTION
Minor changes including new domain name `openloopalliance.com`

(Note we will not have DNS or external network access in the pod network, this domain is just for testing and future/better revisions of the pod network)
