### PR TITLE
Add DESTDIR to make install

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Jenkins server catches them
 
 
 ```
-make clean all install integration
+make DESTDIR="./BUILD" clean all install integration
 ```
 
 **Note:** You will need to install `pytest` for the integration target to work properly


### PR DESCRIPTION
When running make install, you should probably override the destination prefix to `./BUILD` otherwise it will need sudo.

This is called building a root, and by using `DESTDIR` you will be building a root under `./BUILD` instead of `/`