### PR TITLE
Add Unit Testing via Check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_COMMON} ")
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_COMMON} ")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS_COMMON} ")
 
+# Unit tests
+enable_testing()
+
 add_subdirectory (core)
 add_subdirectory (libhw)
 add_subdirectory (libimu)
@@ -16,9 +19,6 @@ add_subdirectory (imu_config)
 add_subdirectory(tests/check)
 
 ###############################################################################
-# Unit tests
-enable_testing()
-add_test(NAME check_money COMMAND check_money)
 
 add_custom_target(integration
                   COMMAND ${CMAKE_COMMAND} -E env CORE_LOCATION=${PROJECT_BINARY_DIR}/core/core pytest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,12 @@ add_subdirectory (libhw)
 add_subdirectory (libimu)
 add_subdirectory (imu_test)
 add_subdirectory (imu_config)
+add_subdirectory(tests/check)
 
+###############################################################################
+# Unit tests
+enable_testing()
+add_test(NAME check_money COMMAND check_money)
 
 add_custom_target(integration
                   COMMAND ${CMAKE_COMMAND} -E env CORE_LOCATION=${PROJECT_BINARY_DIR}/core/core pytest

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@ pipeline {
     stage('Test') {
       steps {
         sh 'make integration'
+        sh 'ctest'
       }
     }
     stage('Build-32bit') {
@@ -31,6 +32,7 @@ pipeline {
     stage('Test-32') {
       steps {
         sh 'make integration'
+        sh 'ctest'
       }
     }
   }

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(_NAME core)
+set(_LIB_NAME libcore)
 
 set(_SRCS
   accel.c
@@ -52,4 +53,17 @@ add_executable (${_NAME} ${_SRCS} ${_HDRS})
 target_link_libraries (${_NAME} LINK_PUBLIC libhw)
 target_link_libraries (${_NAME} LINK_PUBLIC libimu)
 
+# For libcore.a used for testing with ctest
+add_library (${_LIB_NAME} ${_SRCS} ${_HDRS})
+
+target_link_libraries (${_LIB_NAME} LINK_PUBLIC libhw)
+target_link_libraries (${_LIB_NAME} LINK_PUBLIC libimu)
+
+target_include_directories (${_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories (${_LIB_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+install(FILES ${_HDRS} DESTINATION include/${_LIB_NAME})
+install(FILES ${_HDRS} DESTINATION include/${_NAME})
+
 install(TARGETS ${_NAME} DESTINATION bin)
+install(TARGETS ${_LIB_NAME} DESTINATION lib)

--- a/tests/check/CMakeLists.txt
+++ b/tests/check/CMakeLists.txt
@@ -13,3 +13,5 @@ add_executable(${_NAME} ${TEST_SOURCES})
 target_link_libraries(${_NAME} libcore ${CHECK_LIBRARIES})
 
 install(TARGETS ${_NAME} DESTINATION bin)
+
+add_test(NAME ${_NAME} COMMAND ${_NAME})

--- a/tests/check/CMakeLists.txt
+++ b/tests/check/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(_NAME check_pod)
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
+
+find_package(Check REQUIRED)
+include_directories(${CHECK_INCLUDE_DIRS})
+link_directories(${CHECK_LIBRARY_DIRS})
+
+set(TEST_SOURCES
+  check_states.c
+)
+
+add_executable(${_NAME} ${TEST_SOURCES})
+target_link_libraries(${_NAME} libcore ${CHECK_LIBRARIES})
+
+install(TARGETS ${_NAME} DESTINATION bin)

--- a/tests/check/FindCheck.cmake
+++ b/tests/check/FindCheck.cmake
@@ -1,0 +1,56 @@
+# - Try to find the CHECK libraries
+#  Once done this will define
+#
+#  CHECK_FOUND - system has check
+#  CHECK_INCLUDE_DIR - the check include directory
+#  CHECK_LIBRARIES - check library
+#
+#  This configuration file for finding libcheck is originally from
+#  the opensync project. The originally was downloaded from here:
+#  opensync.org/browser/branches/3rd-party-cmake-modules/modules/FindCheck.cmake
+#
+#  Copyright (c) 2007 Daniel Gollub <dgollub@suse.de>
+#  Copyright (c) 2007 Bjoern Ricks  <b.ricks@fh-osnabrueck.de>
+#
+#  Redistribution and use is allowed according to the terms of the New
+#  BSD license.
+#  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+
+INCLUDE( FindPkgConfig )
+
+# Take care about check.pc settings
+PKG_SEARCH_MODULE( CHECK check )
+
+# Look for CHECK include dir and libraries
+IF( NOT CHECK_FOUND )
+	IF ( CHECK_INSTALL_DIR )
+		MESSAGE ( STATUS "Using override CHECK_INSTALL_DIR to find check" )
+		SET ( CHECK_INCLUDE_DIR  "${CHECK_INSTALL_DIR}/include" )
+		SET ( CHECK_INCLUDE_DIRS "${CHECK_INCLUDE_DIR}" )
+		FIND_LIBRARY( CHECK_LIBRARY NAMES check PATHS "${CHECK_INSTALL_DIR}/lib" )
+		FIND_LIBRARY( COMPAT_LIBRARY NAMES compat PATHS "${CHECK_INSTALL_DIR}/lib" )
+		SET ( CHECK_LIBRARIES "${CHECK_LIBRARY}" "${COMPAT_LIBRARY}" )
+	ELSE ( CHECK_INSTALL_DIR )
+		FIND_PATH( CHECK_INCLUDE_DIR check.h )
+		FIND_LIBRARY( CHECK_LIBRARIES NAMES check )
+	ENDIF ( CHECK_INSTALL_DIR )
+
+	IF ( CHECK_INCLUDE_DIR AND CHECK_LIBRARIES )
+		SET( CHECK_FOUND 1 )
+		IF ( NOT Check_FIND_QUIETLY )
+			MESSAGE ( STATUS "Found CHECK: ${CHECK_LIBRARIES}" )
+		ENDIF ( NOT Check_FIND_QUIETLY )
+	ELSE ( CHECK_INCLUDE_DIR AND CHECK_LIBRARIES )
+		IF ( Check_FIND_REQUIRED )
+			MESSAGE( FATAL_ERROR "Could NOT find CHECK" )
+		ELSE ( Check_FIND_REQUIRED )
+			IF ( NOT Check_FIND_QUIETLY )
+				MESSAGE( STATUS "Could NOT find CHECK" )	
+			ENDIF ( NOT Check_FIND_QUIETLY )
+		ENDIF ( Check_FIND_REQUIRED )
+	ENDIF ( CHECK_INCLUDE_DIR AND CHECK_LIBRARIES )
+ENDIF( NOT CHECK_FOUND )
+
+# Hide advanced variables from CMake GUIs
+MARK_AS_ADVANCED( CHECK_INCLUDE_DIR CHECK_LIBRARIES )

--- a/tests/check/check_states.c
+++ b/tests/check/check_states.c
@@ -1,0 +1,26 @@
+#include <check.h>
+#include <pod.h>
+
+
+
+START_TEST(test_get_pod_mode)
+{
+    int rc = init_pod();
+    ck_assert_int_eq(rc, 0);
+    ck_assert_int_eq(get_pod_mode(), POST);
+
+    ck_assert_int_eq(set_pod_mode(Boot, "Test Set Mode"), true);
+    ck_assert_str_eq(get_pod()->state_reason, "Test Set Mode");
+    uint64_t time = get_pod()->last_transition;
+
+    ck_assert_int_eq(set_pod_mode(Boot, "Test Set Mode"), false);
+    ck_assert_str_eq(get_pod()->state_reason, "Test Set Mode");
+
+    ck_assert_int_eq(get_pod()->last_transition, time);
+}
+END_TEST
+
+int main(void)
+{
+    return 0;
+}


### PR DESCRIPTION
This PR adds the support for unit testing using [libcheck](https://libcheck.github.io/check/), a unit testing framework for C projects.

**Summary**

- Compile `core/` into `libcore.a` as well as an executable `core`.  This is required for the `check` framework to build a test binary that tests the functionality defined in core.
   - Eventually core should become libcore, and a wrapper executable that just has a `main()` should be used.
- Tests are defined under the `tests/check/` folder. An initial test `check_states.c` contains an initial test for the state machine.
    - TODO: Port the old state machine tests from July into this file
- Add `ctest` to the Jenkinsfile test stages.


To compile and run tests.

```
cd ./proj
cmake <options> ..
make clean all install
ctest --verbose
```

In summary: CTest is the runner that executes test binaries, Check is the testing library that compiles the test binaries.
